### PR TITLE
Added Cards /api/cards route to get all Pokémon cards

### DIFF
--- a/src/auth/auth.middleware.ts
+++ b/src/auth/auth.middleware.ts
@@ -1,5 +1,5 @@
-import {NextFunction, Request, Response} from "express"
-import jwt from "jsonwebtoken"
+import {NextFunction, Request, Response} from "express";
+import jwt from "jsonwebtoken";
 
 // Étendre le type Request (@see src/types/express.d.ts)
 
@@ -10,34 +10,33 @@ export const authenticateToken = (
     next: NextFunction,
 ): Response|void => {
     // 1. Récupérer le token depuis l'en-tête Authorization
-    const authHeader = req.headers.authorization
-    const token = authHeader && authHeader.split(' ')[1] // Format: "Bearer TOKEN"
+    const authHeader = req.headers.authorization;
+    const token = authHeader && authHeader.split(' ')[1];   // Format: "Bearer TOKEN"
 
     if (!token) {
-        return res.status(401).json({error: "Token manquant"})
-    }
+        return res.status(401).json({error: "Token manquant"});
+    };
 
     try {
         // 2. Vérifier et décoder le token
         const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
             userId: number
             email: string
-        }
+        };
 
         if (!decoded) {
-            return res.status(401).json({error: "Token invalide ou expiré"})
-        }
+            return res.status(401).json({error: "Token invalide ou expiré"});
+        };
 
         // 3. Ajouter userId à la requête pour l'utiliser dans les routes
         req.user = {
             userId: decoded.userId,
             email: decoded.email
-        }
+        };
 
         // 4. Passer au prochain middleware ou à la route
-        next()
+        next();
     } catch (error) {
-        return res.status(401).json({error: "Token invalide ou expiré"})
-    }
-}
-
+        return res.status(401).json({error: "Token invalide ou expiré"});
+    };
+};

--- a/src/auth/auth.route.ts
+++ b/src/auth/auth.route.ts
@@ -1,11 +1,11 @@
-import {Response, Router} from "express"
-import bcrypt from "bcryptjs"
-import jwt from "jsonwebtoken"
+import {Response, Router} from "express";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
 import {prisma} from "../../src/database";
 import {SignUpRequest, SignInRequest} from "../types/express";
 
 // Création du router pour l'authentification
-export const authRouter = Router()
+export const authRouter = Router();
 
 // POST /auth/sign-up
 // Accessible via POST /auth/sign-up
@@ -57,7 +57,7 @@ authRouter.post("/sign-up", async (req: SignUpRequest, res: Response) =>
                 email: newUser.email,
             },
             process.env.JWT_SECRET as string,
-            {expiresIn: '7d'}
+            {expiresIn: "7d"}
         );
 
         // 6. Retourner les infos de l'utilisateur

--- a/src/cards/cards.route.ts
+++ b/src/cards/cards.route.ts
@@ -1,0 +1,28 @@
+import {Request, Response, Router} from "express";
+import {prisma} from "../../src/database";
+import { authenticateToken } from "../auth/auth.middleware";
+
+// Création du router pour les cartes Pokémon
+export const cardsRouter = Router();
+
+// GET /api/cards
+// Accessible via GET /api/cards
+// JWT : S'assure que le token est valide (@see documentation Get All Cards.bru)
+cardsRouter.get("/", authenticateToken, async (req: Request, res: Response) =>
+{
+    // Récupérer toutes les cartes Pokémon
+    try {
+        const cards = await prisma.card.findMany({
+            // Trier les cartes Pokémon par ordre croissant de numéro Pokédex
+            orderBy: {
+                pokedexNumber: "asc"
+            }
+        });
+
+        // Retourner les cartes Pokémon
+        return res.status(200).json(cards);
+    } catch (error) {
+        console.error("Error when getting Pokémon cards:", error);
+        return res.status(500).json({error: "Server error"});
+    }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import {createServer} from "http";
 import {env} from "./env";
 import express from "express";
 import cors from "cors";
-import {authRouter} from "./auth/auth.route"
+import {authRouter} from "./auth/auth.route";
+import {cardsRouter} from "./cards/cards.route";
 
 // Create Express app
 export const app = express();
@@ -24,6 +25,10 @@ app.use(express.static('public'));
 // Utilisation des routeurs spécifiques
 // Authentification (toutes les routes d'authentification seront préfixées par /api/auth)
 app.use("/api/auth", authRouter);
+
+// Cartes Pokémon (toutes les routes de cartes Pokémon seront préfixées par /api/cards)
+// Pour l'instant, il n'y a que GET /api/cards (mais d'autres endpoints seront ajoutés)
+app.use("/api/cards", cardsRouter);
 
 // Health check endpoint
 app.get("/api/health", (_req, res) => {


### PR DESCRIPTION
Implement new API Pokémon cards route to **catch'em all**!
This allow **authentificated Users** (JWT middleware) to fetch every Pokémon cards (see `Get All Cards.bru` docs)

Testing done with **Bruno (Cards >> Get All Cards)**

Here, the JWT expired or wasn't valid anymore. _**GET /api/cards was forbidden by the middleware successfully!**_
<img width="1348" height="782" alt="01" src="https://github.com/user-attachments/assets/667816cb-b5b5-4939-8806-28daea7ad4fd" />

Then, after authentificating once again, all the Pokémon cards were available!
<img width="1348" height="782" alt="02" src="https://github.com/user-attachments/assets/3a32ae03-83c4-49d2-948e-ea826b72d48c" />

Closes #4