### PR TITLE
Added Deck /api/decks routes for CRUD operations on a Deck

### DIFF
--- a/bruno/Decks/Update Deck.bru
+++ b/bruno/Decks/Update Deck.bru
@@ -21,18 +21,22 @@ body:json {
   }
 }
 
+vars:pre-request {
+  deckId: 3
+}
+
 docs {
   Update an existing deck.
-
+  
   Requires authentication and deck ownership.
-
+  
   Variables needed:
   - deckId: The ID of the deck to update (get from Get My Decks response)
-
+  
   Body:
   - name: string (optional) - New name for the deck
   - cards: array of numbers (optional) - Must be exactly 10 valid card IDs if provided
-
+  
   Returns:
   - 200: Deck updated successfully
   - 400: Invalid input (must be exactly 10 valid card IDs if cards provided)

--- a/src/cards/cards.route.ts
+++ b/src/cards/cards.route.ts
@@ -24,5 +24,5 @@ cardsRouter.get("/", authenticateToken, async (req: Request, res: Response) =>
     } catch (error) {
         console.error("Error when getting Pokémon cards:", error);
         return res.status(500).json({error: "Server error"});
-    }
+    };
 });

--- a/src/cards/cards.route.ts
+++ b/src/cards/cards.route.ts
@@ -8,7 +8,7 @@ export const cardsRouter = Router();
 // GET /api/cards
 // Accessible via GET /api/cards
 // JWT : S'assure que le token est valide (@see documentation Get All Cards.bru)
-cardsRouter.get("/", authenticateToken, async (req: Request, res: Response) =>
+cardsRouter.get("/", authenticateToken, async (_req: Request, res: Response) =>
 {
     // Récupérer toutes les cartes Pokémon
     try {
@@ -18,7 +18,7 @@ cardsRouter.get("/", authenticateToken, async (req: Request, res: Response) =>
                 pokedexNumber: "asc"
             }
         });
-
+''
         // Retourner les cartes Pokémon
         return res.status(200).json(cards);
     } catch (error) {

--- a/src/decks/decks.route.ts
+++ b/src/decks/decks.route.ts
@@ -212,3 +212,60 @@ decksRouter.patch("/:id", authenticateToken, async (req: Request, res: Response)
         return res.status(500).json({error: "Server error"});
     };
 });
+
+// DELETE /api/decks/:id
+// Accessible via DELETE /api/decks/:id
+// JWT : S'assure que le token est valide
+decksRouter.delete("/:id", authenticateToken, async (req: Request, res: Response) =>
+{
+    // Récupérer l'ID en paramètre
+    const deckId = Number(req.params.id);
+
+    // Récupérer le Deck par son ID
+    try {
+        // 1. Vérifier si le deck existe
+        const existingDeck = await prisma.deck.findUnique({
+            where: {
+                id: deckId,
+            }
+        });
+
+        if (!existingDeck) {
+            return res.status(404).json({error: "Deck introuvable"});
+        };
+
+        // 2. Vérifier si le deck appartient à l'utilisateur authentifié
+        const deckById = await prisma.deck.findUnique({
+            where: {
+                id: deckId,
+                userId: req.user!.userId,
+            },
+        });
+
+        if (!deckById) {
+            return res.status(403).json({error: "Deck inaccesible"});
+        };
+
+        // 3. Supprimer le Deck et ses dépendances (jointure DeckCard)
+        // Supprimer les cartes associées au Deck via la jointure
+        await prisma.deckCard.deleteMany({
+            where: {
+                deckId: deckId,
+            }
+        });
+        // Supprime le Deck
+        await prisma.deck.delete({
+            where: {
+                id: deckId,
+            }
+        });
+
+        // 4. Retourner la réussite de la suppression
+        return res.status(200).json({
+            message: "Suppression réussie",
+        });
+    } catch (error) {
+        console.error("Error when getting deck by ID:", error);
+        return res.status(500).json({error: "Server error"});
+    };
+});

--- a/src/decks/decks.route.ts
+++ b/src/decks/decks.route.ts
@@ -1,0 +1,60 @@
+import {Request, Response, Router} from "express";
+import {prisma} from "../../src/database";
+import { authenticateToken } from "../auth/auth.middleware";
+
+// TODO: Améliorer la documentation des fonctions
+// TODO: Traduire en français les noms pour les erreurs serveur (500+)
+
+// Création du router pour les decks
+export const decksRouter = Router();
+
+// POST /api/decks
+// Accessible via POST /api/decks
+// JWT : S'assure que le token est valide
+decksRouter.post("/", authenticateToken, async (req: Request, res: Response) =>
+{
+    // Destructuration : extrait les champs name et cards de la requête POST pour en faire des variables distinctes
+    const {name, cards} = req.body;
+
+    // Créer le deck contenant 10 cartes aléatoires exactement
+    try {
+        // 0. Vérifier que tous les champs sont remplis (notamment s'assurer qu'il y a bien 10 cartes)
+        if (!name || !cards || cards.length !== 10) {
+            return res.status(400).json({error: "Données manquantes"});
+        };
+
+        // 1. Vérifier que toutes les IDs de cartes sont valides/existants
+        const existingCards = await prisma.card.findMany({
+            where: {
+                id: {
+                    in: cards,
+                },
+            },
+        });
+
+        // Vérifier la taille puisque findMany renvoie un tableau
+        if (existingCards.length !== 10) {
+            return res.status(400).json({error: "IDs de cartes Pokémon invalides/inexistants"});
+        };
+
+        // 3. Création du deck
+        const newDeck = await prisma.deck.create({
+            data: {
+                name: name,
+                userId: req.user!.userId,   // '!' signifie au compilateur TypeScript que req.user n'est pas null (puisqu'on vérifie avec authenticateToken s'il y a des erreurs)
+                cards: {
+                    createMany: {
+                        // Map() permet d'étaler les 10 cartes en 10 objets distincts auxquels on associe un ID
+                        data: cards.map((cardId: number) => ({cardId})),
+                    },
+                },
+            },
+        });
+
+        // 4. Retourner le deck créé
+        return res.status(201).json(newDeck);
+    } catch (error) {
+        console.error("Error when creating deck:", error);
+        return res.status(500).json({error: "Server error"});
+    }
+});

--- a/src/decks/decks.route.ts
+++ b/src/decks/decks.route.ts
@@ -14,6 +14,7 @@ export const decksRouter = Router();
 decksRouter.post("/", authenticateToken, async (req: Request, res: Response) =>
 {
     // Destructuration : extrait les champs name et cards de la requête POST pour en faire des variables distinctes
+    // TODO : Créer un type pour req.body
     const {name, cards} = req.body;
 
     // Créer le deck contenant 10 cartes aléatoires exactement
@@ -85,7 +86,9 @@ decksRouter.get("/mine", authenticateToken, async (req: Request, res: Response) 
 // JWT : S'assure que le token est valide
 decksRouter.get("/:id", authenticateToken, async (req: Request, res: Response) =>
 {
+    // Récupérer l'ID en paramètre
     const deckId = Number(req.params.id);
+
     // Récupérer le Deck par son ID
     try {
         // 1. Vérifier si le deck existe
@@ -113,12 +116,99 @@ decksRouter.get("/:id", authenticateToken, async (req: Request, res: Response) =
 
         if (!deckById) {
             return res.status(403).json({error: "Deck inaccesible"});
-        }
+        };
 
         // 3. Retourner le Deck
         return res.status(200).json(deckById);
     } catch (error) {
         console.error("Error when getting deck by ID:", error);
+        return res.status(500).json({error: "Server error"});
+    };
+});
+
+// PATCH /api/decks/:id
+// Accessible via PATCH /api/decks/:id
+// JWT : S'assure que le token est valide
+decksRouter.patch("/:id", authenticateToken, async (req: Request, res: Response) =>
+{
+    // Récupérer l'ID en paramètre
+    const deckId = Number(req.params.id);
+
+    // Destructuration : extrait les champs name et cards de la requête PATCH pour en faire des variables distinctes
+    // TODO : Créer un type pour req.body
+    const {name, cards} = req.body;
+
+    // Récupérer le Deck par son ID
+    try {
+        // 0. Vérifier que tous les champs sont remplis (notamment s'assurer qu'il y a bien 10 cartes)
+        if (!name || !cards || cards.length !== 10) {
+            return res.status(400).json({error: "Données manquantes"});
+        };
+
+        // 1. Vérifier que toutes les IDs de cartes sont valides/existants
+        const existingCards = await prisma.card.findMany({
+            where: {
+                id: {
+                    in: cards,
+                },
+            },
+        });
+
+        // Vérifier la taille puisque findMany renvoie un tableau
+        if (existingCards.length !== 10) {
+            return res.status(400).json({error: "IDs de cartes Pokémon invalides/inexistants"});
+        };
+
+        // 2. Vérifier si le deck existe
+        const existingDeck = await prisma.deck.findUnique({
+            where: {
+                id: deckId,
+            }
+        });
+
+        if (!existingDeck) {
+            return res.status(404).json({error: "Deck introuvable"});
+        };
+
+        // 3. Vérifier si le deck appartient à l'utilisateur authentifié
+        const deckById = await prisma.deck.findUnique({
+            where: {
+                id: deckId,
+                userId: req.user!.userId,
+            }
+        });
+
+        if (!deckById) {
+            return res.status(403).json({error: "Deck inaccesible"});
+        };
+
+        // 4. Mettre à jour le Deck
+        const updatedDeck = await prisma.deck.update({
+            where: {
+                id: deckId,
+            },
+            data: {
+                name,
+                cards: {
+                    // Suppression des cartes existantes
+                    deleteMany: {},
+                    // Ajout des nouvelles cartes
+                    createMany: {
+                        // Map() permet d'étaler les 10 cartes en 10 objets distincts auxquels on associe un ID
+                        data: cards.map((cardId: number) => ({cardId})),
+                    },
+                },
+            },
+            // Inclure les cartes du Deck (Prisma s'occupe de lier la jointure DeckCard)
+            include: {
+                cards: true,
+            }
+        })
+
+        // 5. Retourner le Deck mis à jour
+        return res.status(200).json(updatedDeck);
+    } catch (error) {
+        console.error("Error when updating deck by ID:", error);
         return res.status(500).json({error: "Server error"});
     };
 });

--- a/src/decks/decks.route.ts
+++ b/src/decks/decks.route.ts
@@ -56,5 +56,26 @@ decksRouter.post("/", authenticateToken, async (req: Request, res: Response) =>
     } catch (error) {
         console.error("Error when creating deck:", error);
         return res.status(500).json({error: "Server error"});
-    }
+    };
+});
+
+// GET /api/decks/mine
+// Accessible via GET /api/decks/mine
+// JWT : S'assure que le token est valide
+decksRouter.get("/mine", authenticateToken, async (req: Request, res: Response) =>
+{
+    // Récupérer tous les Decks de l'utilisateur authentifié
+    try {
+        const decks = await prisma.deck.findMany({
+            where: {
+                userId: req.user!.userId,   // '!' signifie au compilateur TypeScript que req.user n'est pas null (puisqu'on vérifie avec authenticateToken s'il y a des erreurs)
+            }
+        });
+
+        // Retourner les Decks de l'utilisateur
+        return res.status(200).json(decks);
+    } catch (error) {
+        console.error("Error when getting user's decks:", error);
+        return res.status(500).json({error: "Server error"});
+    };
 });

--- a/src/decks/decks.route.ts
+++ b/src/decks/decks.route.ts
@@ -68,7 +68,7 @@ decksRouter.get("/mine", authenticateToken, async (req: Request, res: Response) 
     try {
         const decks = await prisma.deck.findMany({
             where: {
-                userId: req.user!.userId,   // '!' signifie au compilateur TypeScript que req.user n'est pas null (puisqu'on vérifie avec authenticateToken s'il y a des erreurs)
+                userId: req.user!.userId,
             }
         });
 
@@ -76,6 +76,49 @@ decksRouter.get("/mine", authenticateToken, async (req: Request, res: Response) 
         return res.status(200).json(decks);
     } catch (error) {
         console.error("Error when getting user's decks:", error);
+        return res.status(500).json({error: "Server error"});
+    };
+});
+
+// GET /api/decks/:id
+// Accessible via GET /api/decks/:id
+// JWT : S'assure que le token est valide
+decksRouter.get("/:id", authenticateToken, async (req: Request, res: Response) =>
+{
+    const deckId = Number(req.params.id);
+    // Récupérer le Deck par son ID
+    try {
+        // 1. Vérifier si le deck existe
+        const existingDeck = await prisma.deck.findUnique({
+            where: {
+                id: deckId,
+            }
+        });
+
+        if (!existingDeck) {
+            return res.status(404).json({error: "Deck introuvable"});
+        };
+
+        // 2. Vérifier si le deck appartient à l'utilisateur authentifié
+        const deckById = await prisma.deck.findUnique({
+            where: {
+                id: deckId,
+                userId: req.user!.userId,
+            },
+            // Inclure les cartes du Deck (Prisma s'occupe de lier la jointure DeckCard)
+            include: {
+                cards: true,
+            }
+        });
+
+        if (!deckById) {
+            return res.status(403).json({error: "Deck inaccesible"});
+        }
+
+        // 3. Retourner le Deck
+        return res.status(200).json(deckById);
+    } catch (error) {
+        console.error("Error when getting deck by ID:", error);
         return res.status(500).json({error: "Server error"});
     };
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import express from "express";
 import cors from "cors";
 import {authRouter} from "./auth/auth.route";
 import {cardsRouter} from "./cards/cards.route";
+import {decksRouter} from "./decks/decks.route";
 
 // Create Express app
 export const app = express();
@@ -29,6 +30,9 @@ app.use("/api/auth", authRouter);
 // Cartes Pokémon (toutes les routes de cartes Pokémon seront préfixées par /api/cards)
 // Pour l'instant, il n'y a que GET /api/cards (mais d'autres endpoints seront ajoutés)
 app.use("/api/cards", cardsRouter);
+
+// Decks (toutes les routes de decks seront préfixées par /api/decks)
+app.use("/api/decks", decksRouter);
 
 // Health check endpoint
 app.get("/api/health", (_req, res) => {


### PR DESCRIPTION
Implement new API Deck routes to **create/read/update/delete a Deck**.
This allow **authentificated owners** (JWT middleware) to create a new Deck with exactly 10 cards, get all their decks or only one by ID, update a Deck or delete one.

Testing done with **Bruno (Decks >> Create Deck, Get My Decks, Get Deck by ID, Update Deck, Delete Deck)**

Here, the JWT expired or wasn't valid anymore. **POST /api/decks was forbidden by the middleware successfully!**
<img width="1349" height="784" alt="01" src="https://github.com/user-attachments/assets/fa376f85-7695-44f6-b6f0-aefe7141eecf" />

Then, after authentificating once again, the **User can create a new Deck with 10 Cards**.
<img width="1349" height="784" alt="02" src="https://github.com/user-attachments/assets/5d5ed3a5-d58d-4704-9a6b-7a0ed1d32a51" />

If there are not exactly 10 Cards, it returns an **400 Bad Request error**.
<img width="1349" height="784" alt="03" src="https://github.com/user-attachments/assets/a7cd3398-2bb3-4ea7-9819-883d9404c4eb" />

And if there are inexisting/invalid Pokémon card IDs, it returns an **400 Bad Request error**.
<img width="1350" height="790" alt="04" src="https://github.com/user-attachments/assets/09f0a629-fd68-43b3-89ec-69e82fec09ff" />

**For the following endpoints, JWT authentification is working.**

**GET /api/decks/mine:** the User can successfully retrieve their Decks.
<img width="1350" height="790" alt="03" src="https://github.com/user-attachments/assets/ca178d68-e57d-4051-8dca-6accaef5cea3" />

**GET /api/decks/:id:** the User (owner of the specified Deck) can retrieve a Deck by its ID. It also returns a response containing all the associated Cards.
<img width="1356" height="795" alt="03" src="https://github.com/user-attachments/assets/924c574b-363a-451e-8547-c8e141512acc" />

- If the User enters an inexisting Deck ID, it returns an **404 Not Found error**.
- If the User tries to get a Deck that isn't its, it returns an **403 Forbidden error**.

**PATCH /api/decks/:id:** the User (owner of the specified Deck) can update a Deck by its ID. It also returns a response containing all the associated Cards.
<img width="1356" height="795" alt="01" src="https://github.com/user-attachments/assets/3cca43dc-2f4b-47e2-b836-7195ed87bcf7" />

- If the User enters an inexisting Deck ID, it returns an **404 Not Found error**.
- If the User tries to get a Deck that isn't its, it returns an **403 Forbidden error**.

**DELETE /api/decks/:id** the User (owner of the specified Deck) can delete an existing Deck by its ID. It deletes all associated Cards.
<img width="1356" height="795" alt="01" src="https://github.com/user-attachments/assets/13d4bfd6-d671-4aa7-ba15-b54b726168d7" />

- If the User enters an inexisting Deck ID, it returns an **404 Not Found error**.
- If the User tries to get a Deck that isn't its, it returns an **403 Forbidden error**.

Closes #5